### PR TITLE
Rename module Sum -> Exercise

### DIFF
--- a/exercises/02-higher-order-functions/recursion/sum/solution.exs
+++ b/exercises/02-higher-order-functions/recursion/sum/solution.exs
@@ -1,4 +1,4 @@
-defmodule Sum do
+defmodule Exercise do
   def sum([]), do: 0
   def sum([x|xs]), do: x + sum(xs)
 end

--- a/exercises/02-higher-order-functions/recursion/sum/tests.exs
+++ b/exercises/02-higher-order-functions/recursion/sum/tests.exs
@@ -23,7 +23,7 @@ defmodule Tests do
     @expected expected
 
     test "sum(#{Kernel.inspect(input)}) should be #{expected}" do
-      assert Sum.sum(@input) == @expected
+      assert Exercise.sum(@input) == @expected
     end
   end
 end


### PR DESCRIPTION
When reading the assignment we are expected to make a module Exercise with a function sum/1, but the solution and tests use the module Sum instead of Exercise.